### PR TITLE
fixed parse tree storing

### DIFF
--- a/ProGED/model.py
+++ b/ProGED/model.py
@@ -48,7 +48,7 @@ class Model:
     """
     
     def __init__(self, expr, sym_vars, lhs_vars, sym_params=[], params={}, estimated={}, valid=False,
-                 trees={}, code="", p=1, grammar=None, **kwargs):
+                 p=1, info={}, **kwargs):
         """Initialize a Model with the initial parse tree and information on the task."""
 
         expr, sym_vars, lhs_vars, sym_params = self.check_initialization_input(expr, sym_vars, lhs_vars, sym_params)
@@ -90,25 +90,30 @@ class Model:
         self.unobserved_vars = kwargs.get('unobserved_vars', [])
 
         self.extra_vars = [str(item) for item in self.observed_vars if str(item) not in self.lhs_vars]
-
-        # grammar info
-        self.info = kwargs.get('info', {})
-        self.grammar = grammar
-        self.p = p                             # TODO: CHECK IF CORRECT (BEFORE IT WAS 0 BUT MODELBOX TEST FAILED)
-        self.trees = trees  #trees has form {"code":[p,n]}"
-        self.add_tree(code, p)
+        
+        if "code" in kwargs:
+            code = kwargs["code"]
+        elif "code" in info:
+            code = info["code"]
+            info.pop("code")
+        else:
+            code = "nan"
+        
+        self.p = p
+        self.info = info
+        self.info["trees"] = {code: [p, 1]}
 
     def add_tree(self, code, p):
         """Add a new parse tree to the model.
         
         Arguments:
-            code (str): The parse tree code, expressed as a string of integers.
+            tree_info (dict): Dict, containing at least "code": the parse tree code, expressed as a string of integers.
             p (float): Probability of parse tree.
         """
-        if code in self.trees:
-            self.trees[code][1] += 1
+        if code in self.info["trees"]:
+            self.info["trees"][code][1] += 1
         else:
-            self.trees[code] = [p,1]
+            self.info["trees"][code] = [p,1]
             self.p += p
         
     def set_estimated(self, result, valid=True):

--- a/ProGED/model_box.py
+++ b/ProGED/model_box.py
@@ -54,11 +54,10 @@ class ModelBox:
                              "Set lhs_vars accordingly.")
 
         if str(exprs) in self.models_dict:
-            # extend add_tree first
             if "code" in info:
                 code = info["code"]
             else:
-                code = ""
+                code = "nan"
             self.models_dict[str(exprs)].add_tree(code, p)
         else:
             self.models_dict[str(exprs)] = Model(expr=exprs,
@@ -272,8 +271,8 @@ class ModelBox:
             else: 
                 txt += "\n-> " + str(self.models_dict[m].expr) 
             txt += ", p = " + str(self.models_dict[m].p)
-            txt += ", parse trees = " + str(len(self.models_dict[m].trees))
-            txt += ", valid = " + str(self.models_dict[m].valid)
+            #txt += ", parse trees = " + str(len(self.models_dict[m].trees))
+            #txt += ", valid = " + str(self.models_dict[m].valid)
             if self.models_dict[m].valid:
                 txt += ", error = " + str(self.models_dict[m].get_error())
                 txt += ", time = " + str(self.models_dict[m].get_time())


### PR DESCRIPTION
Fixed bug with ProGED not storing the indices of selected production rules correctly. Now model.info contains a  "trees" with a dict of all {"code": [p,n]"} parse tree details.